### PR TITLE
Updated telescope name

### DIFF
--- a/src/config_um/configs/telescope.toml
+++ b/src/config_um/configs/telescope.toml
@@ -4,7 +4,7 @@ title = "Ultramarine Telescope Baseline Configuration"
 [general]
 f_number = 15.0 # [unitless] (design requirement - need a proper value from Zemax by Heejoo)
 f_eff = "42.047m" # effective focal length at center of FoV (from general report in Zemax analysis tab)
-version = 'Lazuli Mark 10' # Daewook Kim's Space Coronagraph Optical Team Design
+version = 'UM Mark 10' # Daewook Kim's Space Coronagraph Optical Team Design
 field_bias = '0.2degree' # From Zemax model, Surface 1, tilt about X
 design_wavelength = '633.0nm' # From Zemax
 


### PR DESCRIPTION
Changed design name to UM Mark 10

# Description
Changed the key in src/config_um/configs/telescope.toml 'version' from "Lazuli Mark 10" to "UM Mark 10"

---------------------

**NOTE:** Refer to the [UASAL Development Guide](https://teledocs.space/docs/stp202502_0006) for the PR checklist for guidance as well as other general PR information._

